### PR TITLE
Fix/add expense form

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,9 +38,26 @@ function App() {
 
   function addExpenseToList(newExpense) {
     console.log("addNewExpense-app", newExpense);
-    setExpenses((prevExpenses) => [...prevExpenses, newExpense]);
+    //update expenses state
+    const updatedExpenses =[...expenses, newExpense]    
+    setExpenses(updatedExpenses);
+    localStorage.setItem("expensesData", JSON.stringify(updatedExpenses))
+
+    //update specific group w/ new expense
+    setGroups(prevGroups =>{
+      const updatedGroups = prevGroups.map(group =>{
+        if(group.id === newExpense.groupId){
+          return{...group, expenses: [...group.expenses, newExpense]}
+        }
+        return group
+      })
+      //save updated groups to local storage
+      localStorage.setItem("groupsData", JSON.stringify(updatedGroups))
+      return updatedGroups
+    })
   }
   console.log("expenses from app", expenses);
+  
 
   function updateGroup(updatedGroup) {
     setGroups((prevGroups) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,12 @@ function App() {
   const [expenses, setExpenses] = useState(
     JSON.parse(localStorage.getItem("expensesData")) || []
   );
+
   const [memberData, setMemberData] = useState({ name: "", share: "", id: "" });
+
+  //members added from group to expense
+  const [participantData, setParticipantData] = useState({name:"", share:"", id:""}
+  )
 
   function addFriendToList(newFriend) {
     console.log("addNewFriend-app", newFriend);
@@ -56,8 +61,7 @@ function App() {
       return updatedGroups
     })
   }
-  console.log("expenses from app", expenses);
-  
+  console.log("expenses from app", expenses);  
 
   function updateGroup(updatedGroup) {
     setGroups((prevGroups) => {
@@ -86,7 +90,45 @@ function App() {
       return updatedExpenses;
     });
   }
-  
+  //updates expenses states @ global
+  function addParticipantToExpense(expenseId, newParticipant){
+    setExpenses(prevExpense =>{
+      const updatedExpenses = prevExpense.map(expense=>{
+        if(expense.id === expenseId){
+          return{
+            ...expense,
+            participants:[...expense.participants, newParticipant ]
+          }
+        }
+        return expense;
+      })
+      //update local storage w/ participants
+      localStorage.setItem("expensesData", JSON.stringify(updatedExpenses))
+      return updatedExpenses
+    })
+    //Update group w/updated expense
+    setGroups(prevGroups =>{
+      const updatedGroups = prevGroups.map(group => {
+        if(group.id === newParticipant.groupId){
+          return{
+            ...group,
+            expenses: group.expenses.map((expense) =>
+              expense.id === expenseId
+              ?{
+                ...expense,
+                participants: [...expense.participants, newParticipant]
+              }
+              :expense
+            )
+          }
+        }
+        return group
+      })
+      localStorage.setItem("groupsData", JSON.stringify(updatedGroups))
+      return updatedGroups
+    })
+
+  }
 
   const router = createBrowserRouter([
     {
@@ -137,7 +179,10 @@ function App() {
         setMemberData,
         expenses,
         addExpenseToList,
-        updateExpenseInList 
+        updateExpenseInList,
+        participantData,
+        setParticipantData,
+        addParticipantToExpense,
       }}
     >
       <RouterProvider router={router} />

--- a/src/components/AddExpense.jsx
+++ b/src/components/AddExpense.jsx
@@ -6,15 +6,15 @@ import SearchBar from "./SearchBar";
 import ExpenseCategorySelection from './ExpenseCategorySelection'
 import { v4 as uuidv4 } from "uuid";
 
+
 // eslint-disable-next-line react/prop-types
 
 export default function AddExpense({ closeAddExpense, currentGroup }) {
 
   //I'm using context but we can use props
-  const { addExpenseToList, } = useContext(AppContext);
+  const { addExpenseToList } = useContext(AppContext);
   
-  //Generate today's date
-  
+  //Generate today's date  
   const generateDate = () =>{
     const date = new Date()
     // console.log(date)
@@ -30,8 +30,12 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
     category:"",
     description:'',
     id:uuidv4(),
-    groupId:currentGroup.id
+    groupId:currentGroup.id,
+    participants:[]
   });
+
+  //Temp state to hold participant
+  const [selectedParticipant, setSelectedParticipant] = useState(null)
 
   // Handle input changes and updates form data state
   const handleChange = (event, selectOptionName) => {
@@ -50,6 +54,7 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
     }    
   };
 
+
   const addNewExpense = (event) => {
     event.preventDefault();
 
@@ -63,11 +68,18 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
     localStorage.setItem("expensesData", JSON.stringify(storedExpenseData));
     addExpenseToList(expensesData);
     closeAddExpense();
-    toast("New expense added");
-    console.log("expensesData from Addexpense",expensesData)
+    toast("New expense added");    
   };
 
-
+  const addParticipant = () =>{
+    if(selectedParticipant){
+      setExpensesData((prevData) => ({
+        ...prevData,
+        participants: [...prevData.participants, selectedParticipant],
+      }))
+      setSelectedParticipant(null)
+    }
+  } 
  
 
   return (
@@ -146,9 +158,25 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
             <div className='pt-4 mb-auto'>
               <p className='border border-gray-300 border-dashed rounded-md h-[72px] w-full text-left mt-1 p-2 text-gray-500'>placeholder to add receipt</p>
             </div>
+
             <div className='pt-4 mb-auto'>
-              <p >Add members</p>
-              <SearchBar />              
+              <p >Add participants</p>
+              <div className="flex items-center">
+                <SearchBar 
+                  handleParticipantAdded={(participant)=>setSelectedParticipant(participant)}
+                  purpose="participant" //specifies purpose of search bar is participant
+                  groupMembers={currentGroup?.members || []}
+                />
+                <button
+                  onClick={addParticipant}
+                  type="button"
+                  className="px-3 py-2 text-sm border-none rounded-lg h-9 hover:bg-hover bg-button text-light-indigo"
+                >Add</button>
+              </div>
+              {/* DISPLAY PARTICIPANTS     */}
+              <ul>{expensesData.participants.map(participant =>(
+                <li key={participant.id}>{participant.name}</li>))}
+              </ul>
             </div>
             
             <div className="absolute bottom-0 left-0 right-0 flex items-center w-full p-4 bg-light-indigo place-content-end ">

--- a/src/components/AddExpense.jsx
+++ b/src/components/AddExpense.jsx
@@ -47,10 +47,8 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
           ...prevExpensesData,
           [name]: value,
         }));
-    }
-    
+    }    
   };
-
 
   const addNewExpense = (event) => {
     event.preventDefault();
@@ -83,16 +81,16 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
         
         <form
           onSubmit={addNewExpense}
-          className="flex flex-col flex-1 gap-6 overflow-auto border border-none"
+          className="flex flex-col flex-1 gap-6 border border-none"
         >
           <div className="flex flex-col">
-            <div className='flex items-center'>
+            <div className='flex items-start'>
               
-              <div className='relative flex flex-col'>
+              <div className='relative flex flex-col w-full'>
                 <label className="text-sm">
                 Expense name*
                   <input
-                    className="w-full p-2 mt-1 text-left text-gray-500 border border-gray-300 rounded-md h-9"
+                    className="w-full p-2 mt-1 text-left border rounded-md text-input-text border-input-border h-9"
                     type="text"
                     name="name"
                     value={expensesData.name}
@@ -102,33 +100,35 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
                   />
                 </label>
                 
-            </div>            
-
-            <label className='ml-2 text-sm'>
-              Amount*
-              <input 
-                className='w-full p-2 mt-1 text-left text-gray-500 border border-gray-300 rounded-md h-9'
-                type='number'
-                step='0.01'
-                min='0'
-                name='amount'
-                value={expensesData.amount}
-                onChange={handleChange}
-                required
-              />
-            </label>
-            </div>
-            <div className='flex items-start justify-between pt-4'>
-              <div className='flex flex-col'>
-                <p className='text-sm'>Date*</p>
-                <p className='mt-4 text-sm text-input-text '>{generateDate()}</p>
-              </div>
+              </div>            
 
               <label className='ml-2 text-sm'>
-                <ExpenseCategorySelection 
-                  handleChange={handleChange}
+                Amount*
+                <input 
+                  className='w-full p-2 mt-1 text-left border rounded-md text-input-text border-input-border h-9'
+                  type='number'
+                  step={0.01}
+                  min={0.01}
+                  name='amount'
+                  value={expensesData.amount}
+                  onChange={handleChange}
+                  required
                 />
               </label>
+            </div>
+            <div className='flex items-start pt-4 '>
+              <div className='flex flex-col w-full'>
+                <p className='text-sm'>Date*</p>
+                <p className='pl-2 mt-4 text-sm text-input-text'>{generateDate()}</p>
+              </div>
+
+              <div className='flex flex-col w-full'>
+                <p className='w-full pb-1 text-sm'>Category*</p>
+                <ExpenseCategorySelection 
+                  handleChange={handleChange}
+                />  
+              </div>
+                          
             </div>            
             
             <label className='flex flex-col pt-4 text-sm '>

--- a/src/components/AddExpense.jsx
+++ b/src/components/AddExpense.jsx
@@ -107,11 +107,10 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
                     name="name"
                     value={expensesData.name}
                     onChange={handleChange}
-                    maxLength="30"
+                    maxLength={30}
                     required
                   />
-                </label>
-                
+                </label>                
               </div>            
 
               <label className='ml-2 text-sm'>
@@ -139,8 +138,7 @@ export default function AddExpense({ closeAddExpense, currentGroup }) {
                 <ExpenseCategorySelection 
                   handleChange={handleChange}
                 />  
-              </div>
-                          
+              </div>                          
             </div>            
             
             <label className='flex flex-col pt-4 text-sm '>

--- a/src/components/AddExpense.jsx
+++ b/src/components/AddExpense.jsx
@@ -3,26 +3,24 @@ import { AppContext } from "../App";
 import toast from "react-hot-toast";
 import PropTypes from 'prop-types'
 import SearchBar from "./SearchBar";
+import ExpenseCategorySelection from './ExpenseCategorySelection'
+import { v4 as uuidv4 } from "uuid";
 
 // eslint-disable-next-line react/prop-types
 
+export default function AddExpense({ closeAddExpense, currentGroup }) {
 
-export default function AddExpense({ closeAddExpense }) {
   //I'm using context but we can use props
-  const { addExpenseToList } = useContext(AppContext);
-
-  //Maybe move this to a helper function also maybe use uuid library?
-  const generateGroupId = () => {
-    return Math.floor(10000 + Math.random() * 900000);
-  };
+  const { addExpenseToList, } = useContext(AppContext);
+  
   //Generate today's date
+  
   const generateDate = () =>{
     const date = new Date()
-    console.log(date)
+    // console.log(date)
     const formatDate = date.toLocaleDateString()
     return formatDate
   }
-  
   
   // Initialize state for groupsData
   const [expensesData, setExpensesData] = useState({
@@ -31,24 +29,38 @@ export default function AddExpense({ closeAddExpense }) {
     date:generateDate(),
     category:"",
     description:'',
-    id:generateGroupId(),
+    id:uuidv4(),
+    groupId:currentGroup.id
   });
 
   // Handle input changes and updates form data state
-  const handleChange = (event) => {
-    const { name, value } = event.target;
-    setExpensesData((prevExpensesData) => ({
-      ...prevExpensesData,
-      [name]: value,
-    }));
+  const handleChange = (event, selectOptionName) => {
+    
+    if(selectOptionName){
+      setExpensesData(prevExpensesData =>({
+        ...prevExpensesData,
+        [selectOptionName]:event.value,
+      }))
+    } else {
+        const { name, value } = event.target;
+        setExpensesData((prevExpensesData) => ({
+          ...prevExpensesData,
+          [name]: value,
+        }));
+    }
+    
   };
+
 
   const addNewExpense = (event) => {
     event.preventDefault();
+
     //get stored data from local storage or initialize array
     let storedExpenseData = JSON.parse(localStorage.getItem("expensesData")) || [];
+    
     //append new form data to array
     storedExpenseData.push(expensesData);
+    
     //save updated array to local storage
     localStorage.setItem("expensesData", JSON.stringify(storedExpenseData));
     addExpenseToList(expensesData);
@@ -56,6 +68,9 @@ export default function AddExpense({ closeAddExpense }) {
     toast("New expense added");
     console.log("expensesData from Addexpense",expensesData)
   };
+
+
+ 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-800 bg-opacity-75">
@@ -110,23 +125,11 @@ export default function AddExpense({ closeAddExpense }) {
               </div>
 
               <label className='ml-2 text-sm'>
-                Category*
-                <select
-                  className='w-full p-2 mt-1 text-left text-gray-500 border border-gray-300 rounded-md h-9'
-                  name='category'
-                  value={expensesData.category}
-                  onChange={handleChange}
-                  required
-                  >
-                    <option value=''>--</option>
-                    <option value='cat1'>Category-1</option>
-                    <option value='cat2'>Category-2</option>
-                    <option value='cat3'>Category-3</option>
-                </select>              
+                <ExpenseCategorySelection 
+                  handleChange={handleChange}
+                />
               </label>
-            </div>
-
-            
+            </div>            
             
             <label className='flex flex-col pt-4 text-sm '>
               Expense description*
@@ -145,8 +148,7 @@ export default function AddExpense({ closeAddExpense }) {
             </div>
             <div className='pt-4 mb-auto'>
               <p >Add members</p>
-              <SearchBar />
-              
+              <SearchBar />              
             </div>
             
             <div className="absolute bottom-0 left-0 right-0 flex items-center w-full p-4 bg-light-indigo place-content-end ">
@@ -174,4 +176,5 @@ export default function AddExpense({ closeAddExpense }) {
 //Add proptypes validation for eslint
 AddExpense.propTypes = {
   closeAddExpense: PropTypes.func.isRequired,
+  currentGroup: PropTypes.object.isRequired
 }

--- a/src/components/AddGroup.jsx
+++ b/src/components/AddGroup.jsx
@@ -132,7 +132,7 @@ export default function AddGroup({
           <div className="flex flex-col">
             <div className="flex items-start">
               <img
-                src="../images/placeholder.jpg"
+                src="../../images/placeholder.jpg"
                 className="border border-none rounded-full w-[80px] h-[80px] mr-4"
               />
               <div className="relative flex flex-col">

--- a/src/components/AddGroup.jsx
+++ b/src/components/AddGroup.jsx
@@ -26,7 +26,8 @@ export default function AddGroup({ closeAddGroupModal }) {
     description: "",
     allottedBudget: "",
     members: [],
-    category: "",
+    groupType: "",
+    expenses:[]
   });
 
   //render groupID to be visible on form
@@ -75,7 +76,7 @@ export default function AddGroup({ closeAddGroupModal }) {
       return;
     }
 
-    if (groupsData.category === "") {
+    if (groupsData.groupType === "") {
       toast("Please select a Group type");
       return;
     }
@@ -91,7 +92,7 @@ export default function AddGroup({ closeAddGroupModal }) {
     toast("New group added");
   };
 
-  //to ensure member has id
+  //update groupsData by adding new member to members array
   function addMemberToGroup(newMember) {
     setGroupsData((prevData) => ({
       ...prevData,

--- a/src/components/AddMember.jsx
+++ b/src/components/AddMember.jsx
@@ -3,7 +3,10 @@ import { useState } from "react";
 import SearchBar from "./SearchBar";
 import toast from "react-hot-toast";
 
-export default function AddMember({ addMemberToGroup, groupMembers }) {
+export default function AddMember({ 
+  addMemberToGroup, 
+  groupMembers,
+}) {
   const [newMember, setNewMember] = useState("");
 
   function handleMemberSelected(newMember) {
@@ -25,6 +28,8 @@ export default function AddMember({ addMemberToGroup, groupMembers }) {
     }
 
     addMemberToGroup(newMember);
+
+    
   };
 
   return (

--- a/src/components/EditExpense.jsx
+++ b/src/components/EditExpense.jsx
@@ -3,6 +3,7 @@ import { AppContext } from "../App";
 import toast from "react-hot-toast";
 import PropTypes from 'prop-types';
 import SearchBar from "./SearchBar";
+import ExpenseCategorySelection from './ExpenseCategorySelection'
 
 export default function EditExpense({ closeEditExpense, expense }) {
   const { updateExpenseInList} = useContext(AppContext); 
@@ -51,65 +52,55 @@ export default function EditExpense({ closeEditExpense, expense }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-800 bg-opacity-75">
       <div className="relative border w-[535px] h-[625px] rounded-md px-6 pt-6 bg-zinc-50 flex flex-col m-8 font-geologica">
         <div className="flex items-center justify-between pb-4 mb-5 border-b border-border">
-          <h1 className="text-md p-0">Edit Expense</h1>
+          <h1 className="p-0 text-md">Edit Expense</h1>
           <p className="p-0 text-xs text-gray-400">*Mandatory fields</p>
         </div>
         
         <form 
         onSubmit={saveChanges} 
-        className="flex flex-col flex-1 gap-6 overflow-auto border border-none">
-            <div className="flex flex-col">
-            <div className="flex items-center">
-            <div className="relative flex flex-col">
-          <label className="text-sm">
-            Expense name*
-            <input
-              className="w-full p-2 mt-1 text-left text-gray-500 border border-gray-300 rounded-md h-9"
-              type="text"
-              name="name"
-              value={expenseData.name}
-              onChange={handleChange}
-              maxLength="30"
-              required
-            />
-          </label>
-          </div>
-
-          <label className='ml-2 text-sm'>
-            Amount*
-            <input 
-                className='w-full p-2 mt-1 text-left text-gray-500 border border-gray-300 rounded-md h-9'
-                type='number'
-                step='0.01'
-                min='0'
-                name='amount'
-                value={expenseData.amount}
-                onChange={handleChange}
-                required
-              />
-          </label>
-          </div>
-          <div className="flex items-start justify-between pt-4">
-              <div className="flex flex-col">
-                 <p className="text-sm">Date*</p>
-               <p className="mt-4 text-sm text-input-text">{generateDate()}</p>
+        className="flex flex-col flex-1 gap-6 border border-none">
+          <div className="flex flex-col">
+            <div className="flex items-start">
+              <div className="relative flex flex-col w-full">
+                <label className="text-sm">
+                  Expense name*
+                  <input
+                    className="w-full p-2 mt-1 text-left border rounded-md text-input-text border-input-border h-9"
+                    type="text"
+                    name="name"
+                    value={expenseData.name}
+                    onChange={handleChange}
+                    maxLength={30}
+                    required
+                  />
+                </label>
               </div>
 
-          <label className="text-sm">
-            Category*
-            <select
-                className='w-full p-2 mt-1 text-left text-gray-500 border border-gray-300 rounded-md h-9'
-                name='category'
-                value={expenseData.category}
-                onChange={handleChange}
-                required
-              >
-              <option value=''>--</option>
-              <option value='cat1'>Category-1</option>
-              <option value='cat2'>Category-2</option>
-              <option value='cat3'>Category-3</option>
-            </select>
-          </label>
+              <label className='ml-2 text-sm'>
+                Amount*
+                <input 
+                    className='w-full p-2 mt-1 text-left border rounded-md text-input-text border-input-border h-9'
+                    type='number'
+                  step={0.01}
+                  min={0.01}
+                    name='amount'
+                    value={expenseData.amount}
+                    onChange={handleChange}
+                    required
+                  />
+              </label>
+          </div>
+          <div className="flex items-start pt-4">
+            <div className="flex flex-col w-full">
+              <p className="text-sm">Date*</p>
+              <p className="pl-2 mt-4 text-sm text-input-text">{generateDate()}</p>
+            </div>
+            <div className='flex flex-col w-full'>
+              <p className='w-full pb-1 text-sm'>Category*</p>
+              <ExpenseCategorySelection 
+                handleChange={handleChange}
+              />  
+            </div>          
           </div>
 
           <label className='flex flex-col pt-4 text-sm'>
@@ -130,24 +121,25 @@ export default function EditExpense({ closeEditExpense, expense }) {
               </p>
             </div>
 
+          
             <div className="pt-4 mb-auto">
               <p>Add members</p>
               <SearchBar />
             </div>
 
 
-            <div className="absolute bottom-0 left-0 right-0 flex items-center w-full p-4 bg-light-indigo place-content-end">
+            <div className="absolute bottom-0 left-0 right-0 flex items-center w-full gap-2 p-4 bg-light-indigo place-content-end">
               <button
                 type="button"
                 onClick={closeEditExpense}
-                className="mr-2 text-sm"
+                className="text-sm"
               >
                 Close
               </button>
               <button
                 type="button"
                 // onClick={handleDelete}
-                className="px-3 py-2 text-sm border-none rounded-lg hover:bg-red-600 bg-red-500 text-white"
+                className="px-3 py-2 text-sm text-white bg-red-500 border-none rounded-lg hover:bg-red-600"
               >
                 Remove expense
               </button>
@@ -155,7 +147,7 @@ export default function EditExpense({ closeEditExpense, expense }) {
                 type="submit"
                 className="px-3 py-2 text-sm border-none rounded-lg hover:bg-hover bg-button text-light-indigo"
               >
-                Edit Expense
+                Edit expense
               </button>
             </div>
             </div>

--- a/src/components/EditGroupForm.jsx
+++ b/src/components/EditGroupForm.jsx
@@ -21,7 +21,7 @@ export default function EditGroupForm({ group, closeEditGroupFormModal }) {
     id: group.id,
     description: group.description || "",
     allottedBudget: group.allottedBudget || "",
-    category: group.category || "",
+    groupType: group.groupType || "",
     members: group.members || []
   });
 
@@ -35,7 +35,7 @@ export default function EditGroupForm({ group, closeEditGroupFormModal }) {
         id: group.id,
         description: group.description,
         allottedBudget: group.allottedBudget,
-        category: group.category,
+        groupType: group.groupType,
         members: group.members
       });
     }

--- a/src/components/EditGroupForm.jsx
+++ b/src/components/EditGroupForm.jsx
@@ -141,7 +141,7 @@ export default function EditGroupForm({
             <div className="flex flex-col">
               <div className="flex items-start">
                 <img
-                  src="../images/placeholder.jpg"
+                  src="../../images/placeholder.jpg"
                   className="border border-none rounded-full w-[80px] h-[80px] mr-4"
                 />
                 <div className="relative flex flex-col">

--- a/src/components/ExpenseCategorySelection.jsx
+++ b/src/components/ExpenseCategorySelection.jsx
@@ -1,0 +1,35 @@
+import Select from "react-select"
+import PropTypes from 'prop-types'
+
+
+const ExpenseCategorySelection = ({ handleChange }) => {
+
+  const options=[
+    { value: "rentMortgage",label:"Rent/Mortgage 🏠" },
+    { value: "utilities",label:"Utilities 💡" },
+    { value: "groceries",label:"Groceries 🛒" },
+    { value: "fastFood",label:"Fast Food 🍔" },
+    { value: "diningOut",label:"Dining Out 🍽️"},
+    { value: "transportation",label:"Transportation 🚗"},
+  ]
+
+  return(
+    <>
+      <label className='text-sm'>
+        Category*
+        <Select 
+          defaultValue={null}
+          onChange={(selectedOption)=>handleChange(selectedOption, 'category')}
+          options={options} 
+          placeholder="Choose a category"
+        />
+      </label>
+      
+    </>
+  )
+
+}
+ExpenseCategorySelection.propTypes ={
+  handleChange: PropTypes.func.isRequired,}
+
+export default ExpenseCategorySelection

--- a/src/components/ExpenseCategorySelection.jsx
+++ b/src/components/ExpenseCategorySelection.jsx
@@ -12,19 +12,31 @@ const ExpenseCategorySelection = ({ handleChange }) => {
     { value: "diningOut",label:"Dining Out 🍽️"},
     { value: "transportation",label:"Transportation 🚗"},
   ]
+  const customStyles = {
+    option: (provided, state) => ({
+      ...provided,
+      backgroundColor: state.isFocused ? "#D1D5DB" : "white",
+      color: state.isActive ? "black" : "",
+      "&:active": {
+        backgroundColor: "#D1D5DB",
+      },
+      fontSize:'12px'   
+    }),
+    control:(provided)=>({
+      ...provided,
+      fontSize:'12px'
+    })
+  };
 
   return(
-    <>
-      <label className='text-sm'>
-        Category*
-        <Select 
-          defaultValue={null}
-          onChange={(selectedOption)=>handleChange(selectedOption, 'category')}
-          options={options} 
-          placeholder="Choose a category"
-        />
-      </label>
-      
+    <>      
+      <Select 
+        defaultValue={null}
+        onChange={(selectedOption)=>handleChange(selectedOption, 'category')}
+        options={options} 
+        placeholder="Choose a category"
+        styles={customStyles}
+      />
     </>
   )
 

--- a/src/components/GroupTypeSelection.jsx
+++ b/src/components/GroupTypeSelection.jsx
@@ -9,34 +9,35 @@ const GroupTypeSelection = ({ handleChange, groupsData }) => {
   
       <p className='mt-4 text-sm font-normal'>Group type*</p>
       <div className="flex items-center gap-1 mt-2">
-        {groupTypes.map(category =>{
+        {groupTypes.map(groupType =>{
           return(
           <label 
-            key={category}
+            key={groupType}
             className={`text-sm pr-3 py-2 border rounded-md cursor-pointer hover:font-bold border-border ${
-              groupsData.category === category
+              groupsData.groupType === groupType
                 ? 'bg-button text-gray'
                 : 'bg-zinc-50 text-black'
             }`}>
           <input
             className="invisible"
             type="radio"
-            name="category"
-            value={category}
-            checked={groupsData.category === category}          
+            name="groupType"
+            value={groupType}
+            checked={groupsData.groupType === groupType}          
             onChange={handleChange}
           />
-          {category}
+          {groupType}
         </label>)
         })}
       </div>
     </>
   )
 }
+
 GroupTypeSelection.propTypes ={
   handleChange: PropTypes.func.isRequired,
   groupsData: PropTypes.shape({
-    category: PropTypes.string.isRequired,
+    groupType: PropTypes.string.isRequired,
   }).isRequired,
 }
 

--- a/src/components/MembersOnGroup.jsx
+++ b/src/components/MembersOnGroup.jsx
@@ -6,7 +6,7 @@ export default function MembersOnGroup({
 }) {
   const noMembersMessage = (
     <div className="flex items-center m-2">
-      <img src="../images/Profile.svg" className="m-2" />
+      <img src="../../images/Profile.svg" className="m-2" />
       <p className="text-xs text-gray-500">
         There is no one added to expense yet. Try searching and adding from your
         friend list or quickly add someone by entering their user name

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -43,19 +43,19 @@ export default function Navbar() {
       <nav className="w-48">
         <div className="flex items-center pb-12">
           <img
-            src="../images/placeholder.jpg"
+            src="../../images/placeholder.jpg"
             className="w-8 h-8 mr-2 border border-none rounded-full"
           />
           <p className="block text-lg">Brand Name</p>
         </div>
         <div className="flex items-center py-1 my-2 rounded hover:bg-light-indigo">
-          <img src="../images/Home.svg" className="mr-2" />
+          <img src="../../images/Home.svg" className="mr-2" />
           <NavLink className="block" to="/">
             Home
           </NavLink>
         </div>
         <div className="flex items-center py-1 my-6 rounded hover:bg-light-indigo">
-          <img src="../images/Profile.svg" className="mr-2" />
+          <img src="../../images/Profile.svg" className="mr-2" />
           <NavLink className="block" to="/profile">
             Profile
           </NavLink>
@@ -80,7 +80,7 @@ export default function Navbar() {
                     className="flex items-center py-1 my-2 rounded hover:bg-light-indigo"
                   >
                     <img
-                      src="../images/profilePlaceHolder.png"
+                      src="../../images/profilePlaceHolder.png"
                       className="w-6 h-6 mr-2 border border-none rounded-full"
                     />
                     <NavLink className="block " to={`/group/${group.id}`}>
@@ -109,7 +109,7 @@ export default function Navbar() {
                     className="flex items-center py-1 my-2 rounded hover:bg-light-indigo"
                   >
                     <img
-                      src="../images/profilePlaceHolder.png"
+                      src="../../images/profilePlaceHolder.png"
                       className="w-6 h-6 mr-2 border border-none rounded-full"
                     />
 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable no-unused-vars */
 import Select from "react-select";
-import { useContext, useImperativeHandle, useState } from "react";
+import { useContext, useImperativeHandle, useState, useEffect } from "react";
 import { AppContext } from "../App";
 
 const customStyles = {
@@ -15,39 +15,62 @@ const customStyles = {
   }),
 };
 
-export default function SearchBar({ handleMemberSelected, ref }) {
+export default function SearchBar({ 
+  handleMemberSelected, 
+  handleParticipantAdded, 
+  purpose="member", //sets default purpose of search bar to add member to group
+  groupMembers=[],
+  
+}) {  
   //using react select library for component
   const { friends } = useContext(AppContext);
-  const options = friends.map((friend) => {
-    return {
-      value: friend.userName,
-      label: friend.userName,
-    };
-  });
+  
+  //options based on purpose of SearchBar
+  const options = (purpose === 'participant' ? groupMembers : friends).map(person =>({
+    value: person.userName,
+    label: person.userName,
+    id:person.id,
+  }))
+
   const placeHolderMessage =
-    friends.length === 0
-      ? "Please add a friend first"
+    options.length === 0
+      ? (purpose ==="participant" ? "No members in this group": "Please add a friend first")
       : "Search on your list of friends";
-  const isFriendListEmpty = friends.length === 0;
+
+  //if no options to choose
+  const isListEmpty = options.length === 0;
 
   const filterOptions = (option, inputValue) =>
     option.value.toLowerCase().includes(inputValue);
 
-  const [isClearable, setIsClearable] = useState(true);
-  const [isSearchable, setIsSearchable] = useState(true);
-  const [isDisabled, setIsDisabled] = useState(isFriendListEmpty);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isRtl, setIsRtl] = useState(false);
+  const [isClearable] = useState(true);
+  const [isSearchable] = useState(true);
+  const [isDisabled, setIsDisabled] = useState(isListEmpty);
+  const [isLoading] = useState(false);
+  const [isRtl] = useState(false);
 
-  function addSelectionToForm(optionselected) {
-    if (!optionselected) {
+  //update isDisabled state when change groupMember or friends
+  useEffect(()=>{
+    setIsDisabled(isListEmpty)
+  },[groupMembers, friends, isListEmpty])
+
+  function addSelectionToForm(optionSelected) {
+    if (!optionSelected) {
       return;
     }
-    const selectedFriend = friends.filter(
-      (friend) => friend.userName === optionselected.value
-    );
-    const newMember = selectedFriend[0];
-    handleMemberSelected(newMember);
+
+    const selectedPerson = (purpose==='participant'? groupMembers: friends).find(
+      (person)=> person.userName === optionSelected.value
+    )
+    
+    
+    //call appropriate handler based on purpose of prop
+    if(purpose==="member" && handleMemberSelected){
+      handleMemberSelected(selectedPerson);
+    } else if(purpose==="participant" && handleParticipantAdded){
+      handleParticipantAdded(selectedPerson)
+    }
+    
   }
 
   return (

--- a/src/pages/Expenses.jsx
+++ b/src/pages/Expenses.jsx
@@ -18,14 +18,15 @@ export default function Expenses() {
   };
 
   return (
-    <div className="p-4">
+    <div className="">
       {expenses.length === 0 ? (
         <p>No expenses found.</p>
       ) : (
         expenses.map((expense)=>(
-          <div  key={expense.id} className="border border-gray-300 rounded-md p-4 flex justify-between items-center">
-          <div className="flex flex-col">
-            <h3>{expense.name}</h3>
+          <div key={expense.id} className="flex items-center justify-between p-4 my-2 border border-gray-300 rounded-md">
+          <div className="flex gap-2">
+            <p className="text-sm font-bold">{expense.name}</p>
+            <p className="text-sm">{expense.category}</p>
             </div>
             <button type="button" className="hover:bg-gray-200" onClick={() => openEditExpense(expense)}><img src="../../images/Edit.svg" alt="Edit" /></button>
         </div>

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -14,11 +14,11 @@ export default function Groups() {
 
   // Find the current group based on the groupId
   const currentGroup = groups.find((group) => group.id === Number(groupId));
+  console.log('current group expenses:',currentGroup?.expenses)
   
   function openEditGroupFormModal() {
     setIsEditGroupFormModalOpen(true)
   }
-
   function closeEditGroupFormModal() {
     setIsEditGroupFormModalOpen(false)
   }
@@ -38,7 +38,7 @@ export default function Groups() {
               <img className='w-32 h-32 p-3 rounded-full' src='../images/placeholder.jpg'/>
               <div className="absolute px-2 py-1 text-xs font-light text-gray-700 transform -translate-x-1/2 bg-white border-2 left-1/2 top-24 rounded-xl">
 
-                {currentGroup?.category}
+                {currentGroup?.groupType}
               </div>
             </div>
             <div className='w-full pl-3'>
@@ -85,6 +85,7 @@ export default function Groups() {
               <AddExpense 
                 closeAddExpense ={closeAddExpense} 
                 addExpenseToList={addExpenseToList}
+                currentGroup={currentGroup}
               />
             }
             {isEditGroupFormModalOpen && (

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -1,5 +1,5 @@
-import { NavLink, Outlet, useParams } from "react-router-dom";
-import { useState, useContext } from "react";
+import { NavLink, Outlet, useParams, useNavigate } from "react-router-dom";
+import { useState, useContext, useEffect } from "react";
 import { AppContext } from "../App";
 import EditGroupForm from "../components/EditGroupForm";
 import AddExpense from "../components/AddExpense";
@@ -8,6 +8,7 @@ import EditAddFriendModal from "../components/EditAddFriendModal";
 export default function Groups() {
   const { groupId } = useParams(); // Get the groupId from the URL
   const { groups } = useContext(AppContext); // Get all groups from context
+  const navigate = useNavigate()  
 
   const [isEditGroupFormModalOpen, setIsEditGroupFormModalOpen] =
     useState(false);
@@ -19,6 +20,12 @@ export default function Groups() {
   const currentGroup = groups.find((group) => group.id === Number(groupId));
 
   console.log('current group expenses:',currentGroup?.expenses)  
+
+  useEffect(()=>{
+    if(currentGroup){
+      navigate(`expenses`) //auto navigate to expense page when group loads
+    }
+  },[currentGroup, navigate])
 
   function openEditGroupFormModal() {
     setIsEditGroupFormModalOpen(true);

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -19,7 +19,7 @@ export default function Groups() {
   // Find the current group based on the groupId
   const currentGroup = groups.find((group) => group.id === Number(groupId));
 
-  console.log('current group expenses:',currentGroup?.expenses)  
+  //console.log('current group expenses:',currentGroup?.expenses)  
 
   useEffect(()=>{
     if(currentGroup){
@@ -55,10 +55,9 @@ export default function Groups() {
             <div className="relative min-w-max">
               <img
                 className="w-32 h-32 p-3 rounded-full"
-                src="../images/placeholder.jpg"
+                src="../../images/placeholder.jpg"
               />
               <div className="absolute px-2 py-1 text-xs font-light text-gray-700 transform -translate-x-1/2 bg-white border-2 left-1/2 top-24 rounded-xl">
-
 
                 {currentGroup?.groupType}
 
@@ -78,7 +77,7 @@ export default function Groups() {
 
             <img
               className="h-4"
-              src="../images/Setting.svg"
+              src="../../images/Setting.svg"
               onClick={openEditGroupFormModal}
             />
           </div>
@@ -87,7 +86,7 @@ export default function Groups() {
             <div className="flex items-center w-1/2">
               <img
                 className="w-8 h-8 rounded-full"
-                src="../images/placeholder.jpg"
+                src="../../images/placeholder.jpg"
               />
               <p className="pl-2 text-sm text-gray-500">
                 {currentGroup?.members.length} members


### PR DESCRIPTION
* Add participants to add new expense using group member list.
* changed 'category' to 'groupType' to distinguish  between group type and expense category.
* Set expenses page to auto open when group is open.
* Add dual purpose to SearchBar so it can handle adding members to group or adding participant to expense.
* Matched styling in Add expense form and Edit expense form.
* Styling on Expenses section of Group page.