### PR TITLE
Exit without changes confirmation modal

### DIFF
--- a/src/components/ConfirmationModal.jsx
+++ b/src/components/ConfirmationModal.jsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+
+const ConfirmationModal = ({ isOpen, onConfirm, onCancel }) => {
+  if (!isOpen) return null;
+
+  return (
+<div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-800 bg-opacity-75 ">
+<div className="relative bg-white pt-6 pl-6 pr-6 pb-16 rounded-[8px] shadow-xl w-[535px] h-[183px]">
+  <h2 className="text-[14px] mb-3 font-medium text-title">Close Overlay?</h2>
+  <div className="border-t bg-border h-[1px]"/>
+  <p className="text-[12px] text-gray-600 mt-4 leading-[16.5px] text-modal-text">
+     Are you sure you want to close this overlay? All entered information will be lost.
+  </p>
+  <div className="absolute bottom-0 left-0 right-0 flex items-center w-full p-2 bg-light-indigo place-content-end rounded-b-[8px]">
+    <button onClick={onCancel} className="font-normal text-sm px-3 py-2 mr-2 text-gray-600 rounded-[8px] hover:text-gray-800">Cancel</button>
+    <button onClick={onConfirm} className="font-bold text-sm px-3 py-2 mr-2  bg-red-600 rounded-lg hover:bg-red-800 text-light-indigo">Close Without Saving</button>
+  </div>
+</div>
+</div>
+  );
+};
+
+ConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ConfirmationModal;

--- a/src/components/EditExpense.jsx
+++ b/src/components/EditExpense.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import SearchBar from "./SearchBar";
 import ExpenseCategorySelection from "./ExpenseCategorySelection";
 import DeleteExpenseModal from "./DeleteExpenseModal";
+import ConfirmationModal from "./ConfirmationModal";
 
 export default function EditExpense({ closeEditExpense, expense }) {
   const { updateExpenseInList, deleteExpenseInList } = useContext(AppContext);
@@ -19,6 +20,8 @@ export default function EditExpense({ closeEditExpense, expense }) {
   });
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isConfirmCloseOpen, setIsConfirmCloseOpen] = useState(false); //confirmation modal
+  const [changesMade, setChangesMade] = useState(false); // Track if changes were made
 
   useEffect(() => {
     if (expense) {
@@ -32,6 +35,7 @@ export default function EditExpense({ closeEditExpense, expense }) {
       ...prevData,
       [name]: value,
     }));
+    setChangesMade(true);
   };
 
   const saveChanges = (event) => {
@@ -56,6 +60,23 @@ export default function EditExpense({ closeEditExpense, expense }) {
     closeEditExpense(); // Close the form after deletion
     setIsModalOpen(false); // This closes the modal
     toast(`Expense ${expenseName} was deleted`);
+  };
+
+  const handleClose = () => {
+    if (changesMade) {
+      setIsConfirmCloseOpen(true); // Open confirmation modal
+    } else {
+      closeEditExpense();
+    }
+  };
+
+  const confirmClose = () => {
+    setIsConfirmCloseOpen(false);
+    closeEditExpense();
+  };
+
+  const cancelClose = () => {
+    setIsConfirmCloseOpen(false);
   };
 
   return (
@@ -110,7 +131,8 @@ export default function EditExpense({ closeEditExpense, expense }) {
               </div>
               <div className="flex flex-col w-full">
                 <p className="w-full pb-1 text-sm">Category*</p>
-                <ExpenseCategorySelection handleChange={handleChange} />
+                <ExpenseCategorySelection handleChange={handleChange} 
+                category={expenseData.category}/>
               </div>
             </div>
 
@@ -140,7 +162,7 @@ export default function EditExpense({ closeEditExpense, expense }) {
             <div className="absolute bottom-0 left-0 right-0 flex items-center w-full gap-2 p-4 bg-light-indigo place-content-end">
               <button
                 type="button"
-                onClick={closeEditExpense}
+                onClick={handleClose}
                 className="text-sm"
               >
                 Close
@@ -168,6 +190,12 @@ export default function EditExpense({ closeEditExpense, expense }) {
         onConfirm={confirmDelete}
         onCancel={() => setIsModalOpen(false)}
         expenseName={expenseData.name}
+      />
+
+<ConfirmationModal
+        isOpen={isConfirmCloseOpen}
+        onConfirm={confirmClose}
+        onCancel={cancelClose}
       />
     </div>
   );


### PR DESCRIPTION
Added confirmation modal for the edit expense form that confirms whether a user wants to close the edited expense without saving any changes