### PR TITLE
Home page styles and addGroup click outside

### DIFF
--- a/src/components/AddGroup.jsx
+++ b/src/components/AddGroup.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect, useRef } from "react";
 import { AppContext } from "../App";
 import toast from "react-hot-toast";
 import PropTypes from "prop-types";
@@ -14,6 +14,7 @@ export default function AddGroup({
   openLinkAddFriendModal,
 }) {
   const { addGroupToList } = useContext(AppContext);
+  const modalRef = useRef()
 
   //Maybe move this to a helper function also maybe use uuid library?
   const generateGroupId = () => {
@@ -42,6 +43,19 @@ export default function AddGroup({
           expenses: [],
         }
   );
+
+  //Close modals when click outside of modal
+  useEffect(()=>{  
+    const handleClickOutside = (e) =>{      
+      if (modalRef.current && !modalRef.current.contains(e.target)){
+        closeAddGroupModal()
+      }    
+    }
+      document.body.addEventListener('mousedown',handleClickOutside)
+      return () => {
+        document.body.removeEventListener('mousedown',handleClickOutside)
+      }    
+  }, [closeAddGroupModal])
 
   //render groupID to be visible on form
   const renderGroupId = () => {
@@ -135,7 +149,7 @@ export default function AddGroup({
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-gray-800 bg-opacity-75">
-      <div className="relative w-full max-w-[535px] sm:w-11/12 md:w-10/12 lg:w-3/4 xl:w-[535px] h-auto rounded-md px-6 pt-6 bg-zinc-50 flex flex-col m-4 font-geologica">
+      <div ref={modalRef} className="relative w-full max-w-[535px] sm:w-11/12 md:w-10/12 lg:w-3/4 xl:w-[535px] h-auto rounded-md px-6 pt-6 bg-zinc-50 flex flex-col m-4 font-geologica">
         <div className="flex items-center justify-between pb-4 mb-5 border-b border-border">
           <h1 className="p-0 text-md">New Group</h1>
           <p className="p-0 text-xs text-gray-400">*Mandatory fields</p>
@@ -146,7 +160,7 @@ export default function AddGroup({
           className="flex flex-col flex-1 gap-6 border-none "
         >
           <div className="flex flex-col">
-            <div className="flex md:items-start flex-col md:flex-row">
+            <div className="flex flex-col md:items-start md:flex-row">
               <img
                 src="../../images/placeholder.jpg"
                 className="border border-none rounded-full w-[80px] h-[80px] mr-4 mb-4 md:mb-0 self-center "
@@ -155,7 +169,7 @@ export default function AddGroup({
                 <label className="text-sm">
                   Group name*
                   <input
-                    className="w-full p-2 md:mt-1 text-left border rounded-md text-input-text border-input-border h-9"
+                    className="w-full p-2 text-left border rounded-md md:mt-1 text-input-text border-input-border h-9"
                     type="text"
                     name="name"
                     value={groupsData.name}
@@ -164,15 +178,15 @@ export default function AddGroup({
                     required
                   />
                 </label>
-                <p className="text-xs text-gray-400 mb-4 md:mb-0">30 character max.</p>
+                <p className="mb-4 text-xs text-gray-400 md:mb-0">30 character max.</p>
                 {renderGroupId()}
               </div>
 
               <div className="relative flex flex-col">
-                <label className="md:ml-2 text-sm">
+                <label className="text-sm md:ml-2">
                   Allotted budget
                   <input
-                    className="w-full p-2 md:mt-1 text-left border rounded-md text-input-text border-input-border h-9"
+                    className="w-full p-2 text-left border rounded-md md:mt-1 text-input-text border-input-border h-9"
                     type="number"
                     step={0.01}
                     min={0.01}
@@ -185,11 +199,11 @@ export default function AddGroup({
                     required
                   />
                 </label>
-                <p className="md:ml-2 text-xs text-gray-400 mb-4 md:mb-0">$1,000,000 max.</p>
+                <p className="mb-4 text-xs text-gray-400 md:ml-2 md:mb-0">$1,000,000 max.</p>
               </div>
             </div>
 
-            <label className="flex flex-col md:pt-4 text-sm">
+            <label className="flex flex-col text-sm md:pt-4">
               Group description*
               <textarea
                 className="w-full p-2 mt-1 text-left border rounded-md resize-none text-input-text border-input-border"
@@ -226,7 +240,7 @@ export default function AddGroup({
               </Link>
             </div>
 
-            <div className="md:pb-12 pb-6 mt-2 overflow-y-auto">
+            <div className="pb-6 mt-2 overflow-y-auto md:pb-12">
               <MembersOnGroup
                 groupMembers={groupsData.members}
                 deleteMemberFromGroup={deleteMemberFromGroup}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -23,6 +23,7 @@ export default function Navbar() {
   function closeAddGroupModal() {
     setIsAddGroupModalOpen(false);
   }
+
   function openAddFriendModal() {
     setIsAddFriendModalOpen(true);
   }
@@ -32,7 +33,6 @@ export default function Navbar() {
   function openLinkAddFriendModal() {
     setIsLinkAddFriendModalOpen(true);
   }
-
   function closeLinkAddFriendModal() {
     setIsLinkAddFriendModalOpen(false);
     setIsAddGroupModalOpen(true);

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -6,7 +6,8 @@ import AddExpense from "../components/AddExpense";
 import EditAddFriendModal from "../components/EditAddFriendModal";
 import RemainingBudget from "../helpers/RemainingBudget";
 
-const getNavLinkClass = ({ isActive })=> isActive ? "px-2 py-1 text-sm bg-border rounded-t-md text-tab-text" : "px-2 py-1 text-sm text-button"
+const getNavLinkClass = ({ isActive })=> 
+   `${isActive ? "px-2 py-1 text-sm bg-border rounded-t-md text-tab-text" : "px-2 py-1 text-sm text-button"} hover:text-tab-text`
 
 export default function Groups() {
   const { groupId } = useParams(); // Get the groupId from the URL
@@ -64,11 +65,11 @@ export default function Groups() {
   return (
     <>
       <div className="flex flex-col max-w-[785px] w-full gap-6 font-geologica mx-3 mt-6">
-        <div className="p-6 md:mt-12 border rounded-md border-border bg-zinc-50">
-          <div className="relative flex justify-between w-full flex-col md:flex-row">
-            <div className="relative min-w-max self-center">
+        <div className="p-6 border rounded-md md:mt-12 border-border bg-zinc-50">
+          <div className="relative flex flex-col justify-between w-full md:flex-row">
+            <div className="relative self-center min-w-max">
               <img
-                className="w-24 h-24 rounded-full mb-5 border-border"
+                className="w-24 h-24 mb-5 rounded-full border-border"
                 src="../../images/placeholder.jpg"
               />
               <div className="absolute px-2 py-1 text-xs font-light text-gray-700 transform -translate-x-1/2 bg-white border-2 left-1/2 bottom-3 rounded-xl">
@@ -122,7 +123,7 @@ export default function Groups() {
               </div>
 
               <button
-                className="hidden md:block px-3 py-2 text-sm border-none rounded-lg hover:bg-hover bg-button text-light-indigo"
+                className="hidden px-3 py-2 text-sm border-none rounded-lg md:block hover:bg-hover bg-button text-light-indigo"
                 onClick={openAddExpense}
               >
                 New expense
@@ -151,13 +152,13 @@ export default function Groups() {
             )}
           </div>
           <button
-            className="md:hidden px-3 py-2 text-sm border-none rounded-lg hover:bg-hover bg-button text-light-indigo w-full mt-4"
+            className="w-full px-3 py-2 mt-4 text-sm border-none rounded-lg md:hidden hover:bg-hover bg-button text-light-indigo"
             onClick={openAddExpense}
           >
             New expense
           </button>
         </div>        
-        <div className="border rounded-t-md border-b-border">
+        <div className="">
           <NavLink className={getNavLinkClass} to={`expenses`}>
             Expenses
           </NavLink>   

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,7 +2,7 @@ import { NavLink, Outlet, useNavigate, useLocation} from "react-router-dom";
 import { useEffect } from 'react'
 
 const getNavLinkClass = ({ isActive }) => 
-  isActive ? "px-2 py-1 text-sm bg-border rounded-t-md text-tab-text" : "px-2 py-1 text-sm text-button"
+  `${isActive ? "px-2 py-1 text-sm bg-border rounded-t-md text-tab-text" : "px-2 py-1 text-sm text-button"} hover:text-tab-text`
 
 export default function Home() {
   const navigate = useNavigate();
@@ -31,7 +31,7 @@ export default function Home() {
               <p className='text-xs text-gray-600'>You&apos;re going to get</p>
               <p className='text-xl font-semibold text-green'>$AMOUNT</p>
             </div>            
-            <img src="../../public/images/VectorGreen.svg" className="w-[67px] mr-6 h-[43px]"></img>
+            <img src="../../images/VectorGreen.svg" className="w-[67px] mr-6 h-[43px]"></img>
           </div>
 
           <div className='flex items-center w-1/3 mt-12 border rounded-md border-border bg-zinc-50'>
@@ -39,10 +39,10 @@ export default function Home() {
               <p className='text-xs text-gray-600'>You owe</p>
               <p className='text-xl font-semibold text-red-700'>$AMOUNT</p>
             </div>            
-            <img src="../../public/images/VectorRed.svg" className="w-[67px] mr-6 h-[43px]"></img>
+            <img src="../../images/VectorRed.svg" className="w-[67px] mr-6 h-[43px]"></img>
           </div>
         </div>
-        <div className="border rounded-t-md border-b-border">
+        <div className="">
           <NavLink className={getNavLinkClass} to={`expenses-user`}>
             Your expenses
           </NavLink>   


### PR DESCRIPTION
Fixed img paths on home page so they should work in Netlify.
On home and group pages, added hover styling to tabs and removed border.
On addGroup form, added functionality to close modal by clicking outside of the modal (on the background).