### PR TITLE
fix/ edit group form

### DIFF
--- a/src/components/EditGroupForm.jsx
+++ b/src/components/EditGroupForm.jsx
@@ -10,7 +10,8 @@ import { Link } from "react-router-dom";
 import ConfirmationModal from "./ConfirmationModal";
 
 export default function EditGroupForm({
-  group,
+  tempGroupData,
+  setTempGroupData,
   closeEditGroupFormModal,
   openAddFriendModal,
 }) {
@@ -22,31 +23,14 @@ export default function EditGroupForm({
   const blockInvalidChar = (e) =>
     ["e", "E", "+", "-"].includes(e.key) && e.preventDefault();
 
-  // Temporary state for handling input changes
-  const [tempGroupData, setTempGroupData] = useState({
-    name: group.name || "",
-    id: group.id,
-    description: group.description || "",
-    allottedBudget: group.allottedBudget || "",
-    groupType: group.groupType || "",
-    members: group.members || []
-
-  });  
-
   useEffect(() => {
     // This ensures the form is pre-filled with the group data when opened
-    if (group) {
+    if (tempGroupData) {
       setTempGroupData({
-        name: group.name,
-        id: group.id,
-        description: group.description,
-        allottedBudget: group.allottedBudget,
-        groupType: group.groupType,
-        members: group.members
-
+        ...tempGroupData,
       });
     }
-  }, [group]);
+  }, [tempGroupData]);
 
   // Handle input changes in the temporary state
   const handleChange = (e) => {
@@ -98,7 +82,7 @@ export default function EditGroupForm({
 
   const confirmDelete = () => {
     const groupName = tempGroupData.name;
-    deleteGroup(group.id); // Call deleteGroup with the group's ID
+    deleteGroup(tempGroupData.id); // Call deleteGroup with the group's ID
     closeEditGroupFormModal(); // Close the form after deletion
     setIsModalOpen(false); // This closes the modal
     navigate("/");
@@ -273,7 +257,8 @@ export default function EditGroupForm({
 }
 
 EditGroupForm.propTypes = {
-  group: PropTypes.object.isRequired,
+  tempGroupData: PropTypes.object.isRequired,
+  setTempGroupData: PropTypes.func.isRequired,
   closeEditGroupFormModal: PropTypes.func.isRequired,
   openAddFriendModal: PropTypes.func.isRequired,
 };

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -19,9 +19,11 @@ export default function Groups() {
   const [isAddFriendModalOpen, setIsAddFriendModalOpen] = useState(false);
 
   const currentGroup = groups.find((group) => group.id === Number(groupId));
+  const [tempGroupData, setTempGroupData] = useState(currentGroup);
 
   useEffect(() => {
     if (currentGroup) {
+      setTempGroupData(currentGroup);
       navigate(`expenses`); //auto navigate to expense page when group loads
     }
   }, [currentGroup, navigate]);
@@ -139,7 +141,8 @@ export default function Groups() {
             )}
             {isEditGroupFormModalOpen && (
               <EditGroupForm
-                group={currentGroup} // Pass the current group's data as props
+                tempGroupData={tempGroupData} 
+                setTempGroupData={setTempGroupData}
                 closeEditGroupFormModal={closeEditGroupFormModal}
                 openAddFriendModal={openAddFriendModal}
               />


### PR DESCRIPTION
Refactor editGroupForm and Groups component to fix this issue which Hilda mentioned in today's meeting.

4. Edit Group details not retained when user adds a new friend to the group.
Steps: Open an existing group > Click on Edit icon > Change group name from "Party" to "Baby Shower" (say) > Add a new friend > Group name still "Party".
