### PR TITLE
Fix/expense section

### DIFF
--- a/src/components/Expense.jsx
+++ b/src/components/Expense.jsx
@@ -24,10 +24,6 @@ export default function Expense({expense, showButtons, openReceipt, openEditExpe
     const userIsPaid = hasUser ? hasUser.isPaid : false;
     const userAmountToPay = hasUser ? hasUser.amountToPay : 0;
 
-    const totalAmountToPay = expense.participants.reduce((total, participant) => {
-        return total + (participant.isPaid ? 0 : participant.amountToPay);
-    }, 0);
-
     return (
         <div>
             <div
@@ -53,7 +49,7 @@ export default function Expense({expense, showButtons, openReceipt, openEditExpe
                                 ) : hasUser && userIsPaid ? (
                                     <p className="border rounded-lg border-purple-200 bg-purple-100 text-purple-800">You already <span className="font-bold">paid</span></p>
                                 ) : !hasUser ? (
-                                    <p className="border rounded-lg border-lime-200 bg-lime-100 text-lime-800">Get <span className="font-bold">US${totalAmountToPay.toFixed(2)}</span></p>
+                                    <p className="border rounded-lg border-lime-200 bg-lime-100 text-lime-800">Get <span className="font-bold">US${expense.amount}</span></p>
                                 ) : null}
                             </div>
                         </div>
@@ -143,6 +139,12 @@ export default function Expense({expense, showButtons, openReceipt, openEditExpe
                                     </div>
                                 </React.Fragment>
                             ))}
+                        </div>
+                        <div className="pt-3 mt-3 text-sm border-t grid grid-cols-4">
+                            <p className="col-span-2">Total</p>
+                            <div className="flex justify-end">
+                            <p>${parseFloat(expense.amount).toFixed(2)}</p>
+                            </div>
                         </div>
                     </div>
                 )}

--- a/src/components/UserSummary.jsx
+++ b/src/components/UserSummary.jsx
@@ -41,14 +41,14 @@ export default function UserSummary() {
         <div className="flex w-full gap-2">
           <div className='flex items-center w-1/3 mt-12 border rounded-md border-border bg-zinc-50'>
             <div className='flex flex-col justify-center w-full gap-1 px-3 py-6'>
-              <p className='text-xs text-gray-600'>Your balance</p>
+              <p className='text-xs text-gray-600 font-light'>Your balance</p>
               <p className='text-xl font-semibold text-gray-950'>US$ {totalBalance.toFixed(2)}</p>
             </div> 
           </div>
 
           <div className='flex items-center w-1/3 mt-12 border rounded-md border-border bg-zinc-50'>
             <div className='flex flex-col justify-center w-full gap-1 px-3 py-6'>
-              <p className='text-xs text-gray-600'>You&apos;re going to get</p>
+              <p className='text-xs text-gray-600 font-light'>You&apos;re going to get</p>
               <p className='text-xl font-semibold text-green'>US$ {totalToGet.toFixed(2)}</p>
             </div>            
             <img src="../../images/VectorGreen.svg" className="w-[67px] mr-6 h-[43px]"></img>
@@ -56,7 +56,7 @@ export default function UserSummary() {
 
           <div className='flex items-center w-1/3 mt-12 border rounded-md border-border bg-zinc-50'>
             <div className='flex flex-col justify-center w-full gap-1 px-3 py-6'>
-              <p className='text-xs text-gray-600'>You owe</p>
+              <p className='text-xs text-gray-600 font-light'>You owe</p>
               <p className='text-xl font-semibold text-red-700'>US$ {totalOwe.toFixed(2)}</p>
             </div>            
             <img src="../../images/VectorRed.svg" className="w-[67px] mr-6 h-[43px]"></img>

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -118,7 +118,7 @@ export default function Groups() {
               <div className="flex flex-col">
                 <p className="text-xs text-gray-500">Remaining</p>
                 <p className="text-sm text-gray-950">
-                  US$ {currentGroup?.remainingBudget}
+                  US$ {currentGroup?.remainingBudget.toFixed(2)}
                 </p>
                 
               </div>

--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -4,7 +4,7 @@ import { Toaster } from "react-hot-toast";
 
 export default function RootLayout() {
   return (
-    <div className="flex flex-col min-h-screen md:flex-row">
+    <div className="flex flex-col min-h-screen md:flex-row tracking-wide">
       <Navbar />
       <main className="flex-grow bg-blue-background">
         <div className="flex justify-center w-full ">

--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -4,7 +4,7 @@ import { Toaster } from "react-hot-toast";
 
 export default function RootLayout() {
   return (
-    <div className="flex flex-col h-screen md:flex-row">
+    <div className="flex flex-col min-h-screen md:flex-row">
       <Navbar />
       <main className="flex-grow bg-blue-background">
         <div className="flex justify-center w-full ">


### PR DESCRIPTION
- Display expense amount on "Get $--" badge
- Add Total expense amount on the bottom of each expense section
- Add letter-spacing and font-weight for better readability
- Fix screen height
- Fix remaining budget format to display two decimal places