### PR TITLE
Display expenses in friend page and fix some issues 

### DIFF
--- a/src/components/EditExpense.jsx
+++ b/src/components/EditExpense.jsx
@@ -193,26 +193,44 @@ export default function EditExpense({
       ),
     }));
   };
+
   const addOrUpdateParticipant = (newParticipant) => {
     if (newParticipant) {
       const isParticipantIncluded = expensesData.participants.some(
         (participant) => participant.id === newParticipant.id
       );
-
+  
       setExpensesData((prevData) => {
         const updatedParticipants = isParticipantIncluded
           ? prevData.participants.map(
               (participant) =>
                 participant.id === newParticipant.id
-                  ? newParticipant // Update the existing participant
-                  : participant // Keep other participants unchanged
+                  ? { ...participant, ...newParticipant }  
+                  : participant 
             )
-          : [...prevData.participants, newParticipant]; // Add the new participant
-
-        return { ...prevData, participants: updatedParticipants };
+          : [
+              ...prevData.participants, 
+              { ...newParticipant, sharePercentage: newParticipant.sharePercentage || 0 } 
+            ];
+        
+        const { updatedShares } = calculateAmountsToPay(
+          updatedParticipants,
+          parseFloat(prevData.amount)
+        );
+  
+        const participantsWithUpdatedAmounts = updatedParticipants.map(participant => ({
+          ...participant,
+          amountToPay: updatedShares[participant.id]?.amountToPay || 0, 
+        }));
+  
+        return {
+          ...prevData,
+          participants: participantsWithUpdatedAmounts, 
+        };
       });
     }
   };
+  
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-gray-800 bg-opacity-75">

--- a/src/components/EditExpense.jsx
+++ b/src/components/EditExpense.jsx
@@ -400,6 +400,7 @@ export default function EditExpense({
               <button
                 type="submit"
                 disabled={uploading}
+                className="px-3 py-2 text-sm border-none rounded-lg hover:bg-hover bg-button text-light-indigo"
               > 
                 {uploading ? 'Uploading...': 'Save'} 
               </button>

--- a/src/components/ExpenseParticipant.jsx
+++ b/src/components/ExpenseParticipant.jsx
@@ -103,7 +103,7 @@ export default function ExpenseParticipant({
             onMouseEnter={() => setCurrentlyActiveMember(member.id)}
             onMouseLeave={() => setCurrentlyActiveMember(null)}
           >
-            <div className="flex items-center w-4/12 truncate justify-evenly">
+            <div className="flex items-center w-4/12 truncate justify-start gap-2">
               <button
                 type="button"
                 className={`w-6 h-6 flex items-center justify-center rounded-md  text-black  ${

--- a/src/pages/Expenses.jsx
+++ b/src/pages/Expenses.jsx
@@ -80,7 +80,13 @@ export default function Expenses() {
         <>
           {title && <p className="text-sm text-button">{title}</p>}
           {filteredExpenses.map((expense)=>(
-            <Expense key={expense.id} expense={expense} showButtons={true} openReceipt={openReceipt} openEditExpense={openEditExpense}/>
+            <Expense 
+              key={expense.id} 
+              expense={expense} 
+              showButtons={true} 
+              openReceipt={openReceipt} 
+              openEditExpense={openEditExpense}
+            />
           ))}  
         </>     
       )}

--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -1,16 +1,16 @@
 import { useContext, useState, useEffect, useMemo} from "react";
 import {useParams } from "react-router-dom";
 import { AppContext } from "../App";
-import EditExpense from "../components/EditExpense";
 import { useNavigate } from "react-router-dom";
 import ConfirmationModal from "../components/ConfirmationModal";
+import Expense from "../components/Expense";
 
 export default function Friends() {
 
   const { friends, expenses, groups, deleteFriend, showNotification } = useContext(AppContext)
   const { friendId } = useParams()
-  const [isEditing, setIsEditing] = useState(false);
-  const [selectedExpense, setSelectedExpense] = useState(null);
+  // const [isEditing, setIsEditing] = useState(false);
+  // const [selectedExpense, setSelectedExpense] = useState(null);
   const [title, setTitle] = useState([])
   const [isModalOpen, setIsModalOpen] = useState(false);
   const navigate = useNavigate();
@@ -22,42 +22,34 @@ export default function Friends() {
     expense.participants.some(participant=> participant.id === friendId))
   },[expenses, friendId])
 
-    const openEditExpense = (expense) => {
-      setSelectedExpense(expense);
-      setIsEditing(true);
-    };
-  
-    const closeEditExpense = () => {
-      setIsEditing(false);
-      setSelectedExpense(null);
-    };
-  
-    const openReceipt = () =>{
-      //**TODO */
-      console.log("Receipt Open")
-    }    
-    const currentTitle = useMemo(()=>{
-      const generateTitle = (expense) =>{
-        const group= groups.find(group => group.id === expense.groupId)
-        return group ? group.name : 'Unknown Group'
-      }
 
-      return friendExpenses.map(expense => generateTitle(expense))
-    }, [friendExpenses, groups])
-
-    useEffect(()=>{
-      if(friendExpenses.length > 0){        
-        setTitle(currentTitle)
-      }
-    }, [currentTitle, friendExpenses.length])
   
-  if(!friendId){
-    // console.log('friendId undefined')
-    return
-  }
-  if(!currentFriend){
-    // console.log('Friend not found')
-  }
+    // const openReceipt = () =>{
+    //   //**TODO */
+    //   console.log("Receipt Open")
+    // }    
+  const currentTitle = useMemo(()=>{
+    const generateTitle = (expense) =>{
+      const group= groups.find(group => group.id === expense.groupId)
+      return group ? group.name : 'Unknown Group'
+    }
+
+    return friendExpenses.map(expense => generateTitle(expense))
+  }, [friendExpenses, groups])
+
+  useEffect(()=>{
+    if(friendExpenses.length > 0){        
+      setTitle(currentTitle)
+    }
+  }, [currentTitle, friendExpenses.length])
+  
+  // if(!friendId){
+  //   // console.log('friendId undefined')
+  //   return
+  // }
+  // if(!currentFriend){
+  //   // console.log('Friend not found')
+  // }
 
   const handleDelete =() =>{        
     setIsModalOpen(true)
@@ -120,39 +112,18 @@ export default function Friends() {
             friendExpenses.map((expense, index) => (
               <div key={expense.id}>
                 <p>{title[index]}</p>
-                <div key={expense.id} className="flex items-center justify-between p-4 my-2 border border-gray-300 rounded-md bg-zinc-50">
-                  <div className='flex flex-col gap-2'>
-                    <div className="flex gap-2 bg-zinc-50">
-                      <p className="text-sm font-bold">{expense.name}</p>
-                      <p className="px-1 text-xs border rounded-md bg-light-indigo border-border">{expense.category}</p>
-                    </div>
-                    <p className="text-sm">Placeholder for leftover budget</p>
-                  </div>
-                  <div className='flex gap-4 text-sm'>
-                    <div className='flex flex-col gap-2'>
-                                
-                      <p>Placeholder people remaining</p>
-                    </div>
-                    <div className="flex gap-2">
-                      <button type="button" className="px-1 rounded-md hover:bg-gray-200" onClick={() => openReceipt}><img src="../../images/Ticket.svg" alt="Ticket" /></button>
-                      <button type="button" className="px-1 rounded-md hover:bg-gray-200" onClick={() => openEditExpense(expense)}><img src="../../images/Edit.svg" alt="Edit" /></button>
-                    </div>   
-                  </div>
-                </div>              
+                  <Expense 
+                    key={expense.id} 
+                    expense={expense} 
+                    showButtons={false} 
+                  />
               </div>
             ))
           ):(
             <p>No expenses for this friend</p>
           )}
         </div>
-
-        {isEditing && selectedExpense && currentFriend &&(
-        <EditExpense 
-          expense={selectedExpense} 
-          closeEditExpense={closeEditExpense}
-          currentGroup={currentFriend}
-        />
-      )}
+  
       </div>
       {isModalOpen && (
         <ConfirmationModal

--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -51,12 +51,24 @@ export default function Friends() {
   //   // console.log('Friend not found')
   // }
 
-  const handleDelete =() =>{        
-    setIsModalOpen(true)
-  }
+  const handleDelete = () => {
+    const isParticipantInAnyExpense = friendExpenses.some((expense) =>
+      expense.participants.some((participant) => participant.id === friendId)
+    );
+
+    if (isParticipantInAnyExpense) {
+      showNotification(
+        `You need to remove ${currentFriend?.name} from all expenses before deleting them.`,
+        "error"
+      );
+    } else {
+      setIsModalOpen(true);
+    }
+  };
+
   const confirmDelete = () => {
     deleteFriend(friendId)   
-    setIsModalOpen(false); // This closes the modal
+    setIsModalOpen(false); 
     navigate("/");
     showNotification(`Friend ${currentFriend?.name} was deleted`,'success');
   };


### PR DESCRIPTION
- Display related expenses in each friend page properly
- Add validation to prevent friend deletion if they are participant of any expenses. 
(user can delete the friend after user remove them from all the expenses)
- Add styles to save button in editExpense form
- Fix issue that the adding participant issue in edit expense form. 
(Now app will recalculate the amounts to pay right after user adds new participant.)